### PR TITLE
Reflect changes in upstream PHP workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: shivammathur/setup-php@master
         with:
           php-version: ${{ matrix.php }}
-          extension-csv: mbstring, xdebug
+          extensions: mbstring, xdebug
 
       - name: Download PHP-CS-Fixer
         run: |


### PR DESCRIPTION
shivammathur/setup-php deprecated the `extension-csv` field in favor of the `extensions` field