### PR TITLE
API Payment Requests

### DIFF
--- a/src/Api/Message/Payment/AuthorizationRequest.php
+++ b/src/Api/Message/Payment/AuthorizationRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cakasim\Payone\Sdk\Api\Message\Payment;
+
+use Cakasim\Payone\Sdk\Api\Message\Payment\Parameter\Amount;
+use Cakasim\Payone\Sdk\Api\Message\Payment\Parameter\Currency;
+use Cakasim\Payone\Sdk\Api\Message\Request;
+
+/**
+ * Represents a payment (pre)authorization request.
+ *
+ * @author Fabian Böttcher <me@cakasim.de>
+ * @since 0.1.0
+ */
+class AuthorizationRequest extends Request implements AuthorizationRequestInterface
+{
+    use Amount,
+        Currency;
+
+    /**
+     * @inheritDoc
+     */
+    public function getSubAccountId(): ?string
+    {
+        return $this->parameters['aid'] ?? null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getClearingType(): ?string
+    {
+        return $this->parameters['clearingtype'] ?? null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getReference(): ?string
+    {
+        return $this->parameters['reference'] ?? null;
+    }
+
+    /**
+     * Sets the custom reference of this transaction.
+     *
+     * @param string $reference The reference for this transaction.
+     * @return $this
+     */
+    public function setReference(string $reference): self
+    {
+        $this->parameters['reference'] = $reference;
+        return $this;
+    }
+}

--- a/src/Api/Message/Payment/AuthorizationRequestInterface.php
+++ b/src/Api/Message/Payment/AuthorizationRequestInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cakasim\Payone\Sdk\Api\Message\Payment;
+
+use Cakasim\Payone\Sdk\Api\Message\RequestInterface;
+
+/**
+ * The interface for payment (pre)authorization API requests.
+ *
+ * @author Fabian Böttcher <me@cakasim.de>
+ * @since 0.1.0
+ */
+interface AuthorizationRequestInterface extends RequestInterface
+{
+    /**
+     * Returns the sub account ID.
+     *
+     * @return string|null The sub account ID or null if not set.
+     */
+    public function getSubAccountId(): ?string;
+
+    /**
+     * Returns the clearing type of the transaction.
+     *
+     * @return string|null The clearing type or null if not set.
+     */
+    public function getClearingType(): ?string;
+
+    /**
+     * Returns the custom reference of the transaction.
+     *
+     * @return string|null The custom reference or null if not set.
+     */
+    public function getReference(): ?string;
+
+    /**
+     * Returns the transaction amount.
+     *
+     * @return int|null The amount or null if not set.
+     */
+    public function getAmount(): ?int;
+
+    /**
+     * Returns the transaction currency.
+     *
+     * @return string|null The ISO 4217 3-letter-code of the currency.
+     */
+    public function getCurrency(): ?string;
+}

--- a/src/Api/Message/Payment/CaptureRequest.php
+++ b/src/Api/Message/Payment/CaptureRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cakasim\Payone\Sdk\Api\Message\Payment;
+
+use Cakasim\Payone\Sdk\Api\Message\Payment\Parameter\Amount;
+use Cakasim\Payone\Sdk\Api\Message\Payment\Parameter\Currency;
+use Cakasim\Payone\Sdk\Api\Message\Payment\Parameter\SequenceNumber;
+use Cakasim\Payone\Sdk\Api\Message\Payment\Parameter\TransactionId;
+use Cakasim\Payone\Sdk\Api\Message\Request;
+
+/**
+ * Represents a payment capture request.
+ *
+ * @author Fabian Böttcher <me@cakasim.de>
+ * @since 0.1.0
+ */
+class CaptureRequest extends Request implements CaptureRequestInterface
+{
+    use TransactionId,
+        SequenceNumber,
+        Amount,
+        Currency;
+
+    /**
+     * @inheritDoc
+     */
+    public function __construct(array $parameters)
+    {
+        parent::__construct(array_merge($parameters, [
+            'request' => 'capture',
+        ]));
+    }
+}

--- a/src/Api/Message/Payment/CaptureRequestInterface.php
+++ b/src/Api/Message/Payment/CaptureRequestInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cakasim\Payone\Sdk\Api\Message\Payment;
+
+use Cakasim\Payone\Sdk\Api\Message\RequestInterface;
+
+/**
+ * The interface for payment capturing API requests.
+ *
+ * @author Fabian Böttcher <me@cakasim.de>
+ * @since 0.1.0
+ */
+interface CaptureRequestInterface extends RequestInterface
+{
+    /**
+     * Returns the ID of the transaction.
+     *
+     * @return string|null The transaction ID or null if not set.
+     */
+    public function getTransactionId(): ?string;
+
+    /**
+     * Returns the sequence number.
+     *
+     * @return int|null The sequence number or null if not set.
+     */
+    public function getSequenceNumber(): ?int;
+
+    /**
+     * Returns the capture amount of this request.
+     *
+     * @return int|null The amount or null if not set.
+     */
+    public function getAmount(): ?int;
+
+    /**
+     * Returns the transaction currency.
+     *
+     * @return string|null The ISO 4217 3-letter-code of the currency.
+     */
+    public function getCurrency(): ?string;
+}

--- a/src/Api/Message/Payment/DebitRequest.php
+++ b/src/Api/Message/Payment/DebitRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cakasim\Payone\Sdk\Api\Message\Payment;
+
+use Cakasim\Payone\Sdk\Api\Message\Payment\Parameter\Amount;
+use Cakasim\Payone\Sdk\Api\Message\Payment\Parameter\Currency;
+use Cakasim\Payone\Sdk\Api\Message\Payment\Parameter\SequenceNumber;
+use Cakasim\Payone\Sdk\Api\Message\Payment\Parameter\TransactionId;
+use Cakasim\Payone\Sdk\Api\Message\Request;
+
+/**
+ * Represents a payment debit request.
+ *
+ * @author Fabian Böttcher <me@cakasim.de>
+ * @since 0.1.0
+ */
+class DebitRequest extends Request implements DebitRequestInterface
+{
+    use TransactionId,
+        SequenceNumber,
+        Amount,
+        Currency;
+
+    /**
+     * @inheritDoc
+     */
+    public function __construct(array $parameters)
+    {
+        parent::__construct(array_merge($parameters, [
+            'request' => 'debit',
+        ]));
+    }
+}

--- a/src/Api/Message/Payment/DebitRequestInterface.php
+++ b/src/Api/Message/Payment/DebitRequestInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cakasim\Payone\Sdk\Api\Message\Payment;
+
+use Cakasim\Payone\Sdk\Api\Message\RequestInterface;
+
+/**
+ * The interface for payment debit API requests.
+ *
+ * @author Fabian Böttcher <me@cakasim.de>
+ * @since 0.1.0
+ */
+interface DebitRequestInterface extends RequestInterface
+{
+    /**
+     * Returns the ID of the transaction.
+     *
+     * @return string|null The transaction ID or null if not set.
+     */
+    public function getTransactionId(): ?string;
+
+    /**
+     * Returns the sequence number.
+     *
+     * @return int|null The sequence number or null if not set.
+     */
+    public function getSequenceNumber(): ?int;
+
+    /**
+     * Returns the debit amount of this request.
+     *
+     * @return int|null The amount or null if not set.
+     */
+    public function getAmount(): ?int;
+
+    /**
+     * Returns the transaction currency.
+     *
+     * @return string|null The ISO 4217 3-letter-code of the currency.
+     */
+    public function getCurrency(): ?string;
+}

--- a/src/Api/Message/Payment/Parameter/Amount.php
+++ b/src/Api/Message/Payment/Parameter/Amount.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cakasim\Payone\Sdk\Api\Message\Payment\Parameter;
+
+/**
+ * Implements getter and setter for the amount API request parameter.
+ *
+ * @author Fabian Böttcher <me@cakasim.de>
+ * @since 0.1.0
+ */
+trait Amount
+{
+    /**
+     * @inheritDoc
+     */
+    public function getAmount(): ?int
+    {
+        return isset($this->parameters['amount'])
+            ? (int) $this->parameters['amount']
+            : null;
+    }
+
+    /**
+     * Sets the amount.
+     *
+     * @param int $amount The amount.
+     * @return $this
+     */
+    public function setAmount(int $amount): self
+    {
+        $this->parameters['amount'] = (string) $amount;
+        return $this;
+    }
+}

--- a/src/Api/Message/Payment/Parameter/Currency.php
+++ b/src/Api/Message/Payment/Parameter/Currency.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cakasim\Payone\Sdk\Api\Message\Payment\Parameter;
+
+/**
+ * Implements getter and setter for the currency API request parameter.
+ *
+ * @author Fabian Böttcher <me@cakasim.de>
+ * @since 0.1.0
+ */
+trait Currency
+{
+    /**
+     * @inheritDoc
+     */
+    public function getCurrency(): ?string
+    {
+        return $this->parameters['currency'] ?? null;
+    }
+
+    /**
+     * Sets the currency.
+     *
+     * @param string $currency The transaction ID.
+     * @return $this
+     */
+    public function setCurrency(string $currency): self
+    {
+        $this->parameters['currency'] = $currency;
+        return $this;
+    }
+}

--- a/src/Api/Message/Payment/Parameter/SequenceNumber.php
+++ b/src/Api/Message/Payment/Parameter/SequenceNumber.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cakasim\Payone\Sdk\Api\Message\Payment\Parameter;
+
+/**
+ * Implements getter and setter for the sequence number API request parameter.
+ *
+ * @author Fabian Böttcher <me@cakasim.de>
+ * @since 0.1.0
+ */
+trait SequenceNumber
+{
+    /**
+     * @inheritDoc
+     */
+    public function getSequenceNumber(): ?int
+    {
+        return isset($this->parameters['sequencenumber'])
+            ? (int) $this->parameters['sequencenumber']
+            : null;
+    }
+
+    /**
+     * Sets the sequence number.
+     *
+     * @param int $sequenceNumber The sequence number.
+     * @return $this
+     */
+    public function setSequenceNumber(int $sequenceNumber): self
+    {
+        $this->parameters['sequencenumber'] = (string) $sequenceNumber;
+        return $this;
+    }
+}

--- a/src/Api/Message/Payment/Parameter/TransactionId.php
+++ b/src/Api/Message/Payment/Parameter/TransactionId.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cakasim\Payone\Sdk\Api\Message\Payment\Parameter;
+
+/**
+ * Implements getter and setter for the transaction ID API request parameter.
+ *
+ * @author Fabian Böttcher <me@cakasim.de>
+ * @since 0.1.0
+ */
+trait TransactionId
+{
+    /**
+     * @inheritDoc
+     */
+    public function getTransactionId(): ?string
+    {
+        return $this->parameters['txid'] ?? null;
+    }
+
+    /**
+     * Sets the ID of the transaction.
+     *
+     * @param string $transactionId The transaction ID.
+     * @return $this
+     */
+    public function setTransactionId(string $transactionId): self
+    {
+        $this->parameters['txid'] = $transactionId;
+        return $this;
+    }
+}

--- a/src/Api/Message/Payment/RefundRequest.php
+++ b/src/Api/Message/Payment/RefundRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cakasim\Payone\Sdk\Api\Message\Payment;
+
+use Cakasim\Payone\Sdk\Api\Message\Payment\Parameter\Amount;
+use Cakasim\Payone\Sdk\Api\Message\Payment\Parameter\Currency;
+use Cakasim\Payone\Sdk\Api\Message\Payment\Parameter\SequenceNumber;
+use Cakasim\Payone\Sdk\Api\Message\Payment\Parameter\TransactionId;
+use Cakasim\Payone\Sdk\Api\Message\Request;
+
+/**
+ * Represents a payment refund request.
+ *
+ * @author Fabian Böttcher <me@cakasim.de>
+ * @since 0.1.0
+ */
+class RefundRequest extends Request implements RefundRequestInterface
+{
+    use TransactionId,
+        SequenceNumber,
+        Amount,
+        Currency;
+
+    /**
+     * @inheritDoc
+     */
+    public function __construct(array $parameters)
+    {
+        parent::__construct(array_merge($parameters, [
+            'request' => 'refund',
+        ]));
+    }
+}

--- a/src/Api/Message/Payment/RefundRequestInterface.php
+++ b/src/Api/Message/Payment/RefundRequestInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cakasim\Payone\Sdk\Api\Message\Payment;
+
+use Cakasim\Payone\Sdk\Api\Message\RequestInterface;
+
+/**
+ * The interface for payment refund API requests.
+ *
+ * @author Fabian Böttcher <me@cakasim.de>
+ * @since 0.1.0
+ */
+interface RefundRequestInterface extends RequestInterface
+{
+    /**
+     * Returns the ID of the transaction.
+     *
+     * @return string|null The transaction ID or null if not set.
+     */
+    public function getTransactionId(): ?string;
+
+    /**
+     * Returns the sequence number.
+     *
+     * @return int|null The sequence number or null if not set.
+     */
+    public function getSequenceNumber(): ?int;
+
+    /**
+     * Returns the refund amount of this request.
+     *
+     * @return int|null The amount or null if not set.
+     */
+    public function getAmount(): ?int;
+
+    /**
+     * Returns the transaction currency.
+     *
+     * @return string|null The ISO 4217 3-letter-code of the currency.
+     */
+    public function getCurrency(): ?string;
+}

--- a/tests/Api/Message/Payment/AuthorizationRequestTest.php
+++ b/tests/Api/Message/Payment/AuthorizationRequestTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cakasim\Payone\Sdk\Tests\Api\Message\Payment;
+
+use Cakasim\Payone\Sdk\Api\Message\Payment\AuthorizationRequest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Fabian Böttcher <me@cakasim.de>
+ * @since 0.1.0
+ */
+class AuthorizationRequestTest extends TestCase
+{
+    /**
+     * @testdox Get sub account ID (aid) parameter
+     */
+    public function testGetSubAccountId(): void
+    {
+        // Test missing aid parameter scenario.
+        $request = new AuthorizationRequest([
+            'request' => 'authorization',
+        ]);
+
+        $this->assertNull($request->getSubAccountId());
+
+        // Test existing aid parameter scenario.
+        $request = new AuthorizationRequest([
+            'request' => 'authorization',
+            'aid' => '12345',
+        ]);
+
+        $this->assertEquals('12345', $request->getSubAccountId());
+    }
+
+    /**
+     * @testdox Get clearing type (clearingtype) parameter
+     */
+    public function testGetClearingType(): void
+    {
+        // Test missing clearingtype parameter scenario.
+        $request = new AuthorizationRequest([
+            'request' => 'authorization',
+        ]);
+
+        $this->assertNull($request->getClearingType());
+
+        // Test existing clearingtype parameter scenario.
+        $request = new AuthorizationRequest([
+            'request' => 'authorization',
+            'clearingtype' => 'cc',
+        ]);
+
+        $this->assertEquals('cc', $request->getClearingType());
+    }
+
+    /**
+     * @testdox Get and set reference parameter
+     */
+    public function testGetAndSetReference(): void
+    {
+        // Test missing reference parameter scenario.
+        $request = new AuthorizationRequest([
+            'request' => 'authorization',
+        ]);
+
+        $this->assertNull($request->getReference());
+
+        // Test existing reference parameter scenario.
+        $request = new AuthorizationRequest([
+            'request' => 'authorization',
+            'reference' => 'abc123',
+        ]);
+
+        $this->assertEquals('abc123', $request->getReference());
+        $this->assertSame($request, $request->setReference('xyz987'));
+        $this->assertEquals('xyz987', $request->getReference());
+    }
+}

--- a/tests/Api/Message/Payment/CaptureRequestTest.php
+++ b/tests/Api/Message/Payment/CaptureRequestTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cakasim\Payone\Sdk\Tests\Api\Message\Payment;
+
+use Cakasim\Payone\Sdk\Api\Message\Payment\CaptureRequest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Fabian Böttcher <me@cakasim.de>
+ * @since 0.1.0
+ */
+class CaptureRequestTest extends TestCase
+{
+    /**
+     * @testdox Get and set transaction ID (txid) parameter
+     */
+    public function testGetAndSetTransactionId(): void
+    {
+        // Test missing txid parameter scenario.
+        $request = new CaptureRequest([
+            'request' => 'capture',
+        ]);
+
+        $this->assertNull($request->getTransactionId());
+
+        // Test existing txid parameter scenario.
+        $request = new CaptureRequest([
+            'request' => 'capture',
+            'txid' => '375153957',
+        ]);
+
+        $this->assertEquals('375153957', $request->getTransactionId());
+        $this->assertSame($request, $request->setTransactionId('100000555'));
+        $this->assertEquals('100000555', $request->getTransactionId());
+    }
+
+    /**
+     * @testdox Get and set sequence number (sequencenumber) parameter
+     */
+    public function testGetAndSetSequenceNumber(): void
+    {
+        // Test missing sequencenumber parameter scenario.
+        $request = new CaptureRequest([
+            'request' => 'capture',
+        ]);
+
+        $this->assertNull($request->getSequenceNumber());
+
+        // Test existing txid parameter scenario.
+        $request = new CaptureRequest([
+            'request' => 'capture',
+            'sequencenumber' => '3',
+        ]);
+
+        $this->assertEquals(3, $request->getSequenceNumber());
+        $this->assertSame($request, $request->setSequenceNumber(6));
+        $this->assertEquals(6, $request->getSequenceNumber());
+    }
+
+    /**
+     * @testdox Get and set amount parameter
+     */
+    public function testGetAndSetAmount(): void
+    {
+        // Test missing amount parameter scenario.
+        $request = new CaptureRequest([
+            'request' => 'capture',
+        ]);
+
+        $this->assertNull($request->getAmount());
+
+        // Test existing amount parameter scenario.
+        $request = new CaptureRequest([
+            'request' => 'capture',
+            'amount' => '150',
+        ]);
+
+        $this->assertEquals(150, $request->getAmount());
+        $this->assertSame($request, $request->setAmount(600));
+        $this->assertEquals(600, $request->getAmount());
+    }
+
+    /**
+     * @testdox Get and set currency parameter
+     */
+    public function testGetAndSetCurrency(): void
+    {
+        // Test missing currency parameter scenario.
+        $request = new CaptureRequest([
+            'request' => 'capture',
+        ]);
+
+        $this->assertNull($request->getCurrency());
+
+        // Test existing currency parameter scenario.
+        $request = new CaptureRequest([
+            'request' => 'capture',
+            'currency' => 'EUR',
+        ]);
+
+        $this->assertEquals('EUR', $request->getCurrency());
+        $this->assertSame($request, $request->setCurrency('USD'));
+        $this->assertEquals('USD', $request->getCurrency());
+    }
+}


### PR DESCRIPTION
Interfaces and base classes for general API payment requests are still missing. The aim of this PR is to implement the following interfaces / base classes:

- [x] `Cakasim\Payone\Sdk\Api\Message\Payment\AuthorizationRequestInterface`
- [x] `Cakasim\Payone\Sdk\Api\Message\Payment\AuthorizationRequest`
- [x] `Cakasim\Payone\Sdk\Api\Message\Payment\CaptureRequestInterface`
- [x] `Cakasim\Payone\Sdk\Api\Message\Payment\CaptureRequest`
- [x] `Cakasim\Payone\Sdk\Api\Message\Payment\DebitRequestInterface`
- [x] `Cakasim\Payone\Sdk\Api\Message\Payment\DebitRequest`
- [x] `Cakasim\Payone\Sdk\Api\Message\Payment\RefundRequestInterface`
- [x] `Cakasim\Payone\Sdk\Api\Message\Payment\RefundRequest`